### PR TITLE
Fix argument null handling

### DIFF
--- a/src/TimeSeries.Core/Math/Differencing.cs
+++ b/src/TimeSeries.Core/Math/Differencing.cs
@@ -82,8 +82,10 @@ public static class Differencing
     {
         if (lag < 1)
             throw new ArgumentException("Lag must be greater than 0.");
-        if (differencedData == null || originalData == null)
-            throw new ArgumentNullException("Inputs cannot be null.");
+        if (differencedData == null)
+            throw new ArgumentNullException(nameof(differencedData));
+        if (originalData == null)
+            throw new ArgumentNullException(nameof(originalData));
         if (originalData.Length - startIndex < lag)
             throw new ArgumentException("Not enough original data to restore.");
         if (differencedData.Length + lag + startIndex > originalData.Length && validateAgainstOriginal)


### PR DESCRIPTION
## Summary
- ensure ArgumentNullException identifies the offending parameter

## Testing
- `dotnet test --no-build -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a3e7d634832b97fb4c61e817f93a